### PR TITLE
it appears that require('sys') needs to be require('util') on recent versions of node.js

### DIFF
--- a/lib/apparatus/classifier/bayes_classifier.js
+++ b/lib/apparatus/classifier/bayes_classifier.js
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-var sys = require('sys'),
+var sys = require('util'),
 Classifier = require('./classifier');
 
 var BayesClassifier = function() {

--- a/lib/apparatus/classifier/logistic_regression_classifier.js
+++ b/lib/apparatus/classifier/logistic_regression_classifier.js
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-var sys = require('sys'),
+var sys = require('util'),
      Classifier = require('./classifier');
 
 var sylvester = require('sylvester'),


### PR DESCRIPTION
This patch seemed to work for me -- I'm completely in the dark about backwards compatability (if that's even a concern for your projects) so this may break things horribly on older versions of node.js, but this did work on node v0.7.4-pre, and on a checkout of node from ~3-4 months back.

Thanks!
