### PR TITLE
Implemented sparse observations and configurable additive smoothing.

### DIFF
--- a/lib/apparatus/classifier/bayes_classifier.js
+++ b/lib/apparatus/classifier/bayes_classifier.js
@@ -23,11 +23,12 @@ THE SOFTWARE.
 var util = require('util'),
 Classifier = require('./classifier');
 
-var BayesClassifier = function() {
+var BayesClassifier = function(smoothing) {
     Classifier.call(this);
     this.classFeatures = {};
     this.classTotals = {};
     this.totalExamples = 1; // start at one to smooth
+    this.smoothing = smoothing === undefined ? 1.0 : smoothing;
 };
 
 util.inherits(BayesClassifier, Classifier);
@@ -37,20 +38,33 @@ function addExample(observation, label) {
         this.classFeatures[label] = {};
         this.classTotals[label] = 1; // give an extra for smoothing
     }
-     
-    var i = observation.length;
-    this.totalExamples++;
-    this.classTotals[label]++;
 
-    while(i--) {
-	if(observation[i]) {
-            if(this.classFeatures[label][i]) {
-		this.classFeatures[label][i]++;
+    if(observation instanceof Array){
+        var i = observation.length;
+        this.totalExamples++;
+        this.classTotals[label]++;
+
+        while(i--) {
+	    if(observation[i]) {
+                if(this.classFeatures[label][i]) {
+		    this.classFeatures[label][i]++;
+                } else {
+		    // give an extra for smoothing
+		    this.classFeatures[label][i] = 1 + this.smoothing;
+                }
+	    }
+        }
+    } else {
+        // sparse observation
+        for(var key in observation){
+	    value = observation[key];
+            if(this.classFeatures[label][value]) {
+	        this.classFeatures[label][value]++;
             } else {
-		// give an extra for smoothing
-		this.classFeatures[label][i] = 2;
+	        // give an extra for smoothing
+	        this.classFeatures[label][value] = 1 + this.smoothing;
             }
-	}
+        }
     }
 }
 
@@ -60,17 +74,27 @@ function train() {
 
 function probabilityOfClass(observation, label) {
     var prob = 0;
-    var i = observation.length;
 
-    while(i--) {
-	if(observation[i]) {
-	    // default to 1 for smoothing
-            var count = this.classFeatures[label][i] || 1; 
+    if(observation instanceof Array){
+        var i = observation.length;
 
+        while(i--) {
+	    if(observation[i]) {
+                var count = this.classFeatures[label][i] || this.smoothing; 
+                
+	        // numbers are tiny, add logs rather than take product
+                prob += Math.log(count / this.classTotals[label]);
+	    }
+        };
+    } else {
+        // sparse observation
+        for(var key in observation){
+            var count = this.classFeatures[label][observation[key]] || this.smoothing; 
+            
 	    // numbers are tiny, add logs rather than take product
             prob += Math.log(count / this.classTotals[label]);
-	}
-    };
+        }
+    }
 
     // p(C) * unlogging the above calculation P(X|C)
     prob = (this.classTotals[label] / this.totalExamples) * Math.exp(prob);


### PR DESCRIPTION
(these are the first modifications being sent upstream from the [urlclassy](https://github.com/DrDub/urlcassy) project.
A Chi-square-based feature selection should be coming soon, too.)

Changes:
- Observations can now be an arbitrary object. All values are expected
  to be integers as index in the overall feature vector. The indices that
  appear as values in the observation object are the entries set to 1 in
  the non-sparse entries.

Compare:

nb.addExample([0,0,0,1,0,0,1],'good')
nb.addExample({'alpha':3, 'beta':6}, 'good')

both lines are now equivalent. The keys themselves are ignored, that is the
above line is equivalent to

nb.addExample({'x':3,'y':6}, 'good')
- There is a new argument in the constructor for the smoothing. If missing
  it defaults to 1.0 (the previous value).
